### PR TITLE
Requester pays

### DIFF
--- a/src/main/python/pybuilder_aws_lambda_plugin/__init__.py
+++ b/src/main/python/pybuilder_aws_lambda_plugin/__init__.py
@@ -46,9 +46,13 @@ def upload_helper(project, logger, bucket_name, keyname, data):
     logger.info("Uploading lambda-zip to bucket: '{0}' as key: '{1}'".
                 format(bucket_name, keyname))
     acl = project.get_property('lambda_file_access_control')
+    request_payer = {}
+    if project.get_property("requester_pays"):
+        request_payer["RequestPayer"] = "requester"
     s3.Bucket(bucket_name).put_object(Key=keyname,
                                       Body=data,
-                                      ACL=acl)
+                                      ACL=acl,
+                                      **request_payer)
 
 
 @init

--- a/src/unittest/python/pybuilder_aws_lambda_plugin_tests.py
+++ b/src/unittest/python/pybuilder_aws_lambda_plugin_tests.py
@@ -106,6 +106,21 @@ class UploadZipToS3Test(TestCase):
         self.assertEqual(s3_object_list[0].key, 'palp/latest/palp.zip')
         self.assertEqual(s3_object_list[1].key, 'palp/v123/palp.zip')
 
+    def test_if_upload_to_s3_with_requester_pays_parameter(self):
+        self.project.set_property("requester_pays", True)
+        self.client = boto3.client("s3")
+        self.client.put_bucket_request_payment(Bucket='palp-lambda-zips',
+                                           RequestPaymentConfiguration={
+                                            'Payer': 'Requester'})
+
+        upload_zip_to_s3(self.project, mock.MagicMock(Logger))
+
+        s3_object_list = [
+            o for o in self.s3.Bucket('palp-lambda-zips').objects.all()]
+        self.assertEqual(s3_object_list[0].bucket_name, 'palp-lambda-zips')
+        self.assertEqual(s3_object_list[0].key, 'latest/palp.zip')
+        self.assertEqual(s3_object_list[1].key, 'v123/palp.zip')
+
     @mock_s3
     def test_handle_failure_if_no_such_bucket(self):
         pass


### PR DESCRIPTION
If user has a RequesterPays-Bucket he can set the plugin parameter requester_pays, so the files will be uploaded with RequestPayer=requester parameter
