### PR TITLE
Separate upload and release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.4"
   - "3.5"
   - "pypy"
-  - "pypy3"
 # Travis will clone only 50 commits by default. This project however uses the
 # number of commits to determine the version number. Hence we need ALL the
 # commits. This will make the lone unshallow.

--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,38 @@
 pybuilder_aws_plugin
 ====================
 
-PyBuilder plugin to handle AWS functionality.
+PyBuilder plugin to simplify building projects for Amazon Web Services. The following use cases are supported:
 
-How to use the Plugin
+* Packaging Python code for Lambda_ and uploading the result to S3_.
+* Maintain CloudFormation templates in YAML_ and upload to S3_. Conversion done with cfn-sphere_.
+* Deploy code and templates for a `CloudFormation custom resource backed by a Lambda function`__.
+
+.. _Lambda: https://aws.amazon.com/documentation/lambda/
+.. _S3: http://aws.amazon.com/documentation/s3/
+.. _YAML: http://yaml.org/
+.. _cfn-sphere: https://github.com/cfn-sphere/cfn-sphere
+.. __: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources-lambda.html
+
+Incompatible Changes
+====================
+
+>161 (March 2016) Upload and Release are Separate Steps
+-------------------------------------------------------
+
+Till up to version 161 ``upload_zip_to_s3`` and ``upload_cfn_to_s3`` tasks would upload the files to S3 both under a versioned (``v123``) path and under a ``latest`` path element. This behavior prevents testing the new version before releasing it under the ``latest`` path.
+
+Since the task name "upload" does not imply "release" and since we believe in `Test Driven Development`__ we decided to break backwards compatibility in this case.
+
+From version 162 and onward the "upload" tasks will only upload files to S3 under a versioned path. We provide two new tasks ``lambda_release`` and ``cfn_release`` to explicitly copy the files from the versioned path to the ``latest`` path.
+
+We apologize for the inconvenience and hope that this change will simplify your integration tests.
+
+.. __: https://en.wikipedia.org/wiki/Test-driven_development
+
+Usage
 =====================
-Add plugin dependency to your ``build.py`` (will install directly from PyPi):
+
+Add the following plugin dependency to your ``build.py`` (will install directly from PyPi):
 
 .. code:: python
 
@@ -27,38 +54,48 @@ After this you have the following additional tasks, which are explained below:
 * ``package_lambda_code``
 * ``upload_zip_to_s3``
 * ``upload_cfn_to_s3``
+* ``lambda_release``
+* ``cfn_release``
+* ``upload_custom_resource``
+* ``release_custom_resource``
 
 @Task: package_lambda_code
 --------------------------
-This task assembles the Zip-file (a.k.a. the *lambda-zip*) which will be
-uploaded to S3 with the task ``upload_zip_to_s3``. What is this task doing in
-detail?
+This task `assembles the Zip-file`__ (a.k.a. the *lambda-zip*) which will be
+uploaded to S3_ with the task ``upload_zip_to_s3``. This task consists of the following steps:
 
-Package all dependencies
+.. __: http://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html
+
+Add all dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~
-Every entry in ``build.py`` that is specified by using ``project.depends_on``
-is installed into a temporary directory  using ``pip install -t`` and are then
-copied into the lambda-zip from there. The project property
-``install_dependencies_index_url`` is respected and can be used to set a custom
-index url (e.g. internal ``devpi``) for the installation.
+Install every entry in ``build.py``, that is specified by using ``project.depends_on()``,
+into a temporary directory via ``pip install -t``. These will be included in the resulting lambda-zip. Set the project property
+``install_dependencies_index_url`` to use a custom
+index url (e.g. an internal `PYPI server`__).
 
-Package all own modules
+.. __: http://doc.devpi.net/latest/
+
+Add all own modules
 ~~~~~~~~~~~~~~~~~~~~~~~
 All modules which are found in ``src/main/python/`` are copied directly into
 the lambda-zip.
 
-Package all script files
+Add all script files
 ~~~~~~~~~~~~~~~~~~~~~~~~
 The content of the scripts folder (``src/main/scripts``) in a PyBuilder project
 is normally intended to be placed in ``/usr/bin``. This plugin assumes this
-directory contains script(s) including the lambda handler functions. Therefore
-all files under this folder are copied directly to the root layer (``/``) of
+directory contains scripts including the lambda handler functions. Therefore
+all files under this folder are copied directly to the root directory (``/``) of
 the lambda-zip.
+
+Pack everything into the Zip-file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All these files are packed as a Zip-file that complies with the Lambda_ specification.
 
 @Task: upload_zip_to_s3
 -----------------------
-This task uploads the generated zip to a S3 bucket. The bucket name is to be
-set as follows in ``build.py``:
+This task uploads the generated zip to an S3_ bucket. The bucket name is set in ``build.py``:
 
 .. code:: python
 
@@ -69,7 +106,9 @@ if you need another acl you can overwrite this as follows in ``build.py``:
 
 .. code:: python
 
-    project.set_property('lambda_file_access_control', '<wished_acl>')
+    project.set_property('lambda_file_access_control', '<acl>')
+
+.. _acl:
 
 Possible acl values are:
 
@@ -80,79 +119,68 @@ Possible acl values are:
 * ``bucket-owner-read``
 * ``bucket-owner-full-control``
 
-Further, the plugin assumes that you already have a shell with enabled aws
-access (exported keys or .boto or ...). For that take a look at
-e.g. `afp-cli <https://github.com/ImmobilienScout24/afp-cli>`_
+Furthermore, the plugin assumes that you already have a shell with enabled AWS
+access (exported keys or .boto or ...). `afp-cli <https://github.com/ImmobilienScout24/afp-cli>`_ is a tool to provide temporary credentials for shell users.
 
-The uploaded files will be placed in a directory with the version number,
-and in a ``latest/`` directory, such as:
+The uploaded files will be placed in a directory with the version number like: ``v123/projectname.zip``.
 
-- ``v123/projectname.zip``
-- ``latest/projectname.zip``
-
-You can use the property ``bucket_prefix`` to add a prefix to the uploaded
+Use the property ``bucket_prefix`` to add a prefix to the uploaded
 files. For example:
 
 .. code:: python
 
    project.set_property('bucket_prefix', 'my_lambda/')
 
-This will upload the files to the following files:
+This will upload the zip-file to the following key: ``my_lambda/v123/projectname.zip``
 
-- ``my_lambda/v123/projectname.zip``
-- ``my_lambda/latest/projectname.zip``
+On TeamCity_ you can enable setting a TeamCity build parameter with the key of the uploaded zip-file:
 
-In an TeamCity Environment (teamcity_output = True) you can use the property
-``teamcity_parameter`` to push en ``##teamcity[setParameter name='' value='']``
-event to TeamCity and rewrite this parameter with the name of the uploaded
-zip file. For example:
+.. _TeamCity: https://www.jetbrains.com/teamcity/
+.. code::python
 
-.. code:: python
+    project.set_property('teamcity_output', True)
+    project.set_property('teamcity_parameter', 'my_tc_parameter')
 
-   project.set_property('teamcity_parameter', 'my_tc_parameter')
+After uploading the zip-file to S3_ the plugin will emit a
+
+.. code::
+
+    ##teamcity[setParameter name='my_tc_parameter' value='my_lambda/v123/project-name.zip']
+
+line which TeamCity can parse. You can then use the value in other build steps.
 
 @Task: upload_cfn_to_s3
 -----------------------
 
-
-NOTE: This task is available for Python 2.7 and up, due to CFN-Sphere
+NOTE: This task is available for Python 2.7 and up, due to cfn-sphere_
 dependencies not being available for Python 2.6.
 
-This task converts and uploads the CFN-Sphere template YAML files as JSON to a
-S3 bucket.  The bucket name is to be set as follows in ``build.py``:
+This task converts and uploads the CFN-Sphere template YAML_ files as JSON_ to a
+S3_ bucket.  Set the bucket name in ``build.py``:
 
+.. _JSON: http://www.json.org/
 .. code:: python
 
     project.set_property('bucket_name', 'my_template_bucket')
 
-The default acl for JSON files to be uploaded is ``bucket-owner-full-control``.
-But if you need another acl you can overwrite this as follows in ``build.py``:
-
-.. code:: python
-
-    project.set_property('template_file_access_control', '<wished_acl>')
-
-To define the templates you wish to be uploaded set the property as a list of
-tupels:
+Define the CFN templates to upload via a list of
+tuples in the ``template_files`` property:
 
 .. code:: python
 
     project.set_property('template_files',
         [
-            ('path1','filename1'),
-            ('path2','filename2'),
+            ('path1','filename1.yaml'),
+            ('path2','filename2.yaml'),
             ...
         ])
 
-The uploaded files will be placed in a directory with the version number,
-and in a ``latest/`` directory, such as:
+The uploaded files will be placed in a directory with the version number:
 
 - ``v123/filename1.json``
 - ``v123/filename2.json``
-- ``latest/filename1.json``
-- ``latest/filename2.json``
 
-You can use the property ``template_key_prefix`` to add a prefix to the uploaded
+Use the property ``template_key_prefix`` to add a prefix to the uploaded
 files. For example:
 
 .. code:: python
@@ -163,16 +191,13 @@ This will upload the files to the following files:
 
 - ``my_template/v123/filename1.json``
 - ``my_template/v123/filename2.json``
-- ``my_template/latest/filename1.json``
-- ``my_template/latest/filename2.json``
 
 
-The default acl for templates to be uploaded is ``bucket-owner-full-control``.
-But if you need another acl you can overwrite this as follows in ``build.py``:
+The ACL for the JSON_ files is ``bucket-owner-full-control``. Set another ACL in ``build.py``:
 
 .. code:: python
 
-    project.set_property('template_file_access_control', '<wished_acl>')
+    project.set_property('template_file_access_control', '<acl>')
 
 Possible acl values are:
 
@@ -182,6 +207,30 @@ Possible acl values are:
 * ``authenticated-read``
 * ``bucket-owner-read``
 * ``bucket-owner-full-control``
+
+@Task: lambda_release, cfn_release
+-----------------------------------
+
+These tasks copy the lambda-zip or CFN template files from the versioned path to version independant path named ``latest``. For Example:
+
+- ``my_lambda/v123/my-project.zip`` is copied to ``my_lambda/latest/my-project.zip``
+- ``my_templates/v123/my-cfn.json`` is copied to ``my_templates/latest/my-cfn.json``
+
+This provides a simple release mechanism that follows the "latest greatest" principle. Users can rely on the files under ``latest``to tbe the latest tested version.
+
+@Task: upload_custom_resource, release_custom_resource
+------------------------------------------------------
+
+For CloudFormation custom resources backed by a Lambda function these two tasks provide convenience wrappers to implement an "Update - Test - Release" process:
+
+.. code:: shell
+    \#!/bin/bash
+    set -e
+    pyb upload_custom_resource
+    ./run-integration-test.py
+    pyb release_custom_resource
+
+The ``upload_custom_resource`` task bundles the ``upload_zip_to_s3`` and the ``upload_cfn_to_s3`` task. It is strongly recmomended to *not* use a ``bucket_prefix`` in order to keep the lambda-zip and CFN templates in the same direcory on S3.
 
 Licence
 =======

--- a/README.rst
+++ b/README.rst
@@ -224,7 +224,8 @@ This provides a simple release mechanism that follows the "latest greatest" prin
 For CloudFormation custom resources backed by a Lambda function these two tasks provide convenience wrappers to implement an "Update - Test - Release" process:
 
 .. code:: shell
-    \#!/bin/bash
+
+    #!/bin/bash
     set -e
     pyb upload_custom_resource
     ./run-integration-test.py

--- a/build.py
+++ b/build.py
@@ -18,6 +18,8 @@ version = VCSRevision().get_git_revision_count()
 summary = "PyBuilder plugin to handle AWS functionality"
 authors = [Author('Valentin Haenel', 'valentin@haenel.co'),
            Author('Stefan Neben',    'stefan.neben@gmail.com'),
+           Author('Carsten Rose',    'modebm@gmail.com'),
+           Author('Schlomo Schapiro','schlomo.schapiro@gmail.com')
            ]
 license = 'Apache'
 url = 'https://github.com/ImmobilienScout24/pybuilder_aws_plugin'
@@ -34,7 +36,7 @@ def set_properties(project):
     project.build_depends_on("moto")
     project.set_property('coverage_break_build', False)
     project.set_property('distutils_classifiers', [
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',

--- a/build.py
+++ b/build.py
@@ -4,22 +4,22 @@ import sys
 from pybuilder.core import Author, init, use_plugin
 from pybuilder.vcs import VCSRevision
 
-use_plugin("python.core")
-use_plugin("python.unittest")
-use_plugin("python.install_dependencies")
-use_plugin("python.flake8")
-use_plugin("python.coverage")
-use_plugin("python.distutils")
+use_plugin('python.core')
+use_plugin('python.unittest')
+use_plugin('python.install_dependencies')
+use_plugin('python.flake8')
+use_plugin('python.coverage')
+use_plugin('python.distutils')
 
 
-name = "pybuilder_aws_plugin"
-default_task = "publish"
+name = 'pybuilder_aws_plugin'
+default_task = 'publish'
 version = VCSRevision().get_git_revision_count()
-summary = "PyBuilder plugin to handle AWS functionality"
-authors = [Author('Valentin Haenel', 'valentin@haenel.co'),
-           Author('Stefan Neben',    'stefan.neben@gmail.com'),
-           Author('Carsten Rose',    'modebm@gmail.com'),
-           Author('Schlomo Schapiro','schlomo.schapiro@gmail.com')
+summary = 'PyBuilder plugin to handle AWS functionality'
+authors = [Author('Valentin Haenel',  'valentin@haenel.co'),
+           Author('Stefan Neben',     'stefan.neben@gmail.com'),
+           Author('Carsten Rose',     'modebm@gmail.com'),
+           Author('Schlomo Schapiro', 'schlomo.schapiro@gmail.com'),
            ]
 license = 'Apache'
 url = 'https://github.com/ImmobilienScout24/pybuilder_aws_plugin'
@@ -28,13 +28,13 @@ url = 'https://github.com/ImmobilienScout24/pybuilder_aws_plugin'
 @init
 def set_properties(project):
     project.set_property('install_dependencies_upgrade', True)
-    project.depends_on("boto3")
-    project.depends_on('unittest2')
+    project.depends_on('boto3')
     if sys.version_info[0:2] >= (2, 7):
         project.depends_on('cfn-sphere', '>=0.1.21')
     project.depends_on('httpretty')
-    project.build_depends_on("mock")
-    project.build_depends_on("moto")
+    project.build_depends_on('unittest2')
+    project.build_depends_on('mock')
+    project.build_depends_on('moto')
     project.set_property('coverage_break_build', False)
     project.set_property('distutils_classifiers', [
         'Development Status :: 5 - Production/Stable',

--- a/build.py
+++ b/build.py
@@ -29,6 +29,7 @@ url = 'https://github.com/ImmobilienScout24/pybuilder_aws_plugin'
 def set_properties(project):
     project.set_property('install_dependencies_upgrade', True)
     project.depends_on("boto3")
+    project.depends_on('unittest2')
     if sys.version_info[0:2] >= (2, 7):
         project.depends_on('cfn-sphere', '>=0.1.21')
     project.depends_on('httpretty')

--- a/src/main/python/pybuilder_aws_plugin/__init__.py
+++ b/src/main/python/pybuilder_aws_plugin/__init__.py
@@ -4,22 +4,35 @@
 
 import sys
 
-from pybuilder.core import init
+from pybuilder.core import init, task, depends
 
-from .lambda_tasks import upload_zip_to_s3, package_lambda_code
+from .lambda_tasks import upload_zip_to_s3, package_lambda_code, lambda_release
 
 if sys.version_info[0:2] >= (2, 7):
-    from .cfn_tasks import upload_cfn_to_s3
+    # cfn-sphere needs Python 2.7, skip cfn handling for older Python versions
+    from .cfn_tasks import upload_cfn_to_s3, cfn_release
 
+    @task(description='Release on S3 by copying everything to latest')
+    @depends('lambda_release',
+             'cfn_release')
+    def release_custom_resource():
+        pass
+
+    @task(description='Upload lambda and cfn results to S3')
+    @depends('package_lambda_code',
+             'upload_zip_to_s3',
+             'upload_cfn_to_s3')
+    def upload_custom_resource():
+        pass
 
 @init
 def initialize_plugin(project):
     """ Setup plugin defaults. """
     project.set_property(
-        'lambda_file_access_control', 'bucket-owner-full-control')
+            'lambda_file_access_control', 'bucket-owner-full-control')
     project.set_property('bucket_prefix', '')
 
     project.set_property(
-        'template_file_access_control', 'bucket-owner-full-control')
+            'template_file_access_control', 'bucket-owner-full-control')
     project.set_property('template_key_prefix', '')
     project.set_property('teamcity_parameter', '')

--- a/src/main/python/pybuilder_aws_plugin/cfn_tasks.py
+++ b/src/main/python/pybuilder_aws_plugin/cfn_tasks.py
@@ -3,12 +3,12 @@
 
 from pybuilder.core import task
 
-from .helpers import upload_helper, check_acl_parameter_validity
+from .helpers import upload_helper, copy_helper, check_acl_parameter_validity
 
 
 @task('upload_cfn_to_s3',
       description='Convert & upload CloudFormation templates in JSON '
-      'created out of the CFN-Sphere template YAML files')
+                  'created out of the CFN-Sphere template YAML files')
 def upload_cfn_to_s3(project, logger):
     """
     This task is separate since they only work with Python2 >2.6 by
@@ -23,7 +23,7 @@ def upload_cfn_to_s3(project, logger):
     for path, filename in project.get_property('template_files'):
         template = FileLoader.get_file_from_url(filename, path)
         transformed = CloudFormationTemplateTransformer.transform_template(
-            template)
+                template)
         output = transformed.get_template_json()
 
         bucket_name = project.get_property('bucket_name')
@@ -31,10 +31,23 @@ def upload_cfn_to_s3(project, logger):
         filename = filename.replace('.yml', '.json')
         filename = filename.replace('.yaml', '.json')
         version_path = '{0}v{1}/{2}'.format(
-            key_prefix, project.version, filename)
-        latest_path = '{0}latest/{1}'.format(key_prefix, filename)
+                key_prefix, project.version, filename)
+        # latest_path = '{0}latest/{1}'.format(key_prefix, filename)
 
         acl = project.get_property('template_file_access_control')
         check_acl_parameter_validity('template_file_access_control', acl)
         upload_helper(logger, bucket_name, version_path, output, acl)
-        upload_helper(logger, bucket_name, latest_path, output, acl)
+        # upload_helper(logger, bucket_name, latest_path, output, acl)
+
+@task('cfn_release', description='Copy CFN templates from versioned path to latest path in S3')
+def cfn_release(project, logger):
+    bucket_name = project.get_property('bucket_name')
+    key_prefix = project.get_property('template_key_prefix')
+    acl = project.get_property('template_file_access_control')
+    check_acl_parameter_validity('template_file_access_control', acl)
+
+    for path, filename in project.get_property('template_files'):
+        filename = filename.replace('.yml', '.json').replace('.yaml', '.json')
+        source_key = '{0}v{1}/{2}'.format(key_prefix, project.version, filename)
+        destination_key = '{0}latest/{1}'.format(key_prefix, filename)
+        copy_helper(logger, bucket_name, source_key, destination_key, acl)

--- a/src/main/python/pybuilder_aws_plugin/helpers.py
+++ b/src/main/python/pybuilder_aws_plugin/helpers.py
@@ -18,20 +18,33 @@ permissible_acl_values = [
 def upload_helper(logger, bucket_name, keyname, data, acl):
     s3 = boto3.resource('s3')
     logger.info(
-        'Uploading lambda-zip to bucket: "{0}" as key: "{1}"'
-        .format(bucket_name, keyname))
+            'Uploading to bucket "{0}" key {1}'
+                .format(bucket_name, keyname))
     s3.Bucket(bucket_name).put_object(Key=keyname, Body=data, ACL=acl)
+
+
+def copy_helper(logger, bucket_name, source_key, destination_key, acl):
+    'Copy S3 source_key to destination_key in bucket_name applying acl'
+    logger.info('Copying in {0} from {1} to {2}'.format(bucket_name, source_key, destination_key))
+    client = boto3.client('s3')
+    client.copy_object(ACL=acl,
+                       Bucket=bucket_name,
+                       CopySource={'Bucket': bucket_name,
+                                   'Key':    source_key
+                                   },
+                       Key=destination_key,
+                       MetadataDirective='COPY')
 
 
 def check_acl_parameter_validity(property_, acl_value):
     if acl_value not in permissible_acl_values:
         raise BuildFailedException(
-            "ACL value: '{0}' not allowed for property: '{1}'".
-            format(acl_value, property_))
+                "ACL value: '{0}' not allowed for property: '{1}'".
+                    format(acl_value, property_))
 
 
 def teamcity_helper(tc_param, keyname):
     flush_text_line(
-        "##teamcity[setParameter name='{0}' value='{1}']".format(
-            tc_param, keyname
-        ))
+            "##teamcity[setParameter name='{0}' value='{1}']".format(
+                    tc_param, keyname
+            ))

--- a/src/main/python/pybuilder_aws_plugin/lambda_tasks.py
+++ b/src/main/python/pybuilder_aws_plugin/lambda_tasks.py
@@ -8,6 +8,7 @@ import zipfile
 from pybuilder.core import depends, task
 
 from .helpers import (upload_helper,
+                      copy_helper,
                       teamcity_helper,
                       check_acl_parameter_validity,
                       )
@@ -18,12 +19,12 @@ def zip_recursive(archive, directory, folder=''):
     for item in os.listdir(directory):
         if os.path.isfile(os.path.join(directory, item)):
             archive.write(
-                os.path.join(directory, item), os.path.join(folder, item),
-                zipfile.ZIP_DEFLATED)
+                    os.path.join(directory, item), os.path.join(folder, item),
+                    zipfile.ZIP_DEFLATED)
         elif os.path.isdir(os.path.join(directory, item)):
             zip_recursive(
-                archive, os.path.join(directory, item),
-                folder=os.path.join(folder, item))
+                    archive, os.path.join(directory, item),
+                    folder=os.path.join(folder, item))
 
 
 def as_pip_argument(dependency):
@@ -54,13 +55,13 @@ def prepare_dependencies_dir(logger, project, target_directory, excludes=None):
         process.communicate()
         if process.returncode != 0:
             msg = "Command '{0}' failed to install dependency: {1}".format(
-                cmd, process.returncode)
+                    cmd, process.returncode)
             raise Exception(msg)
 
 
 def get_path_to_zipfile(project):
     return os.path.join(
-        project.expand_path('$dir_target'), '{0}.zip'.format(project.name))
+            project.expand_path('$dir_target'), '{0}.zip'.format(project.name))
 
 
 def write_version(project, archive):
@@ -73,15 +74,18 @@ def write_version(project, archive):
 
 @task('package_lambda_code',
       description='Package the modules, dependencies and scripts into a '
-      'lambda-zip')
-@depends('package')
+                  'lambda-zip')
+@depends('clean',
+         'install_build_dependencies',
+         'publish',
+         'package')
 def package_lambda_code(project, logger):
     dir_target = project.expand_path('$dir_target')
     lambda_dependencies_dir = os.path.join(dir_target, 'lambda_dependencies')
     excludes = ['boto', 'boto3']
     logger.info('Going to prepare dependencies.')
     prepare_dependencies_dir(
-        logger, project, lambda_dependencies_dir, excludes=excludes)
+            logger, project, lambda_dependencies_dir, excludes=excludes)
     logger.info('Going to assemble the lambda-zip.')
     path_to_zipfile = get_path_to_zipfile(project)
     archive = zipfile.ZipFile(path_to_zipfile, 'w')
@@ -107,12 +111,24 @@ def upload_zip_to_s3(project, logger):
     bucket_prefix = project.get_property('bucket_prefix')
     bucket_name = project.get_mandatory_property('bucket_name')
     keyname_version = '{0}v{1}/{2}.zip'.format(
-        bucket_prefix, project.version, project.name)
-    keyname_latest = '{0}latest/{1}.zip'.format(bucket_prefix, project.name)
+            bucket_prefix, project.version, project.name)
+    # keyname_latest = '{0}latest/{1}.zip'.format(bucket_prefix, project.name)
     acl = project.get_property('lambda_file_access_control')
     check_acl_parameter_validity('lambda_file_access_control', acl)
     upload_helper(logger, bucket_name, keyname_version, data, acl)
-    upload_helper(logger, bucket_name, keyname_latest, data, acl)
+    # upload_helper(logger, bucket_name, keyname_latest, data, acl)
     tc_param = project.get_property('teamcity_parameter')
     if project.get_property("teamcity_output") and tc_param:
         teamcity_helper(tc_param, keyname_version)
+
+@task('lambda_release', description='Copy lambda zip file from versioned path to latest path in S3')
+def lambda_release(project,logger):
+    bucket_prefix = project.get_property('bucket_prefix')
+    bucket_name = project.get_mandatory_property('bucket_name')
+    acl = project.get_property('lambda_file_access_control')
+    check_acl_parameter_validity('lambda_file_access_control', acl)
+
+    source_key = '{0}v{1}/{2}.zip'.format(bucket_prefix, project.version, project.name)
+    destination_key = '{0}latest/{1}.zip'.format(bucket_prefix, project.name)
+    copy_helper(logger, bucket_name, source_key, destination_key, acl)
+

--- a/src/main/python/pybuilder_aws_plugin/lambda_tasks.py
+++ b/src/main/python/pybuilder_aws_plugin/lambda_tasks.py
@@ -112,11 +112,9 @@ def upload_zip_to_s3(project, logger):
     bucket_name = project.get_mandatory_property('bucket_name')
     keyname_version = '{0}v{1}/{2}.zip'.format(
             bucket_prefix, project.version, project.name)
-    # keyname_latest = '{0}latest/{1}.zip'.format(bucket_prefix, project.name)
     acl = project.get_property('lambda_file_access_control')
     check_acl_parameter_validity('lambda_file_access_control', acl)
     upload_helper(logger, bucket_name, keyname_version, data, acl)
-    # upload_helper(logger, bucket_name, keyname_latest, data, acl)
     tc_param = project.get_property('teamcity_parameter')
     if project.get_property("teamcity_output") and tc_param:
         teamcity_helper(tc_param, keyname_version)

--- a/src/unittest/python/pybuilder_aws_plugin_tests.py
+++ b/src/unittest/python/pybuilder_aws_plugin_tests.py
@@ -116,8 +116,7 @@ class UploadZipToS3Test(TestCase):
         s3_object_list = [
             o for o in self.s3.Bucket('palp-lambda-zips').objects.all()]
         self.assertEqual(s3_object_list[0].bucket_name, 'palp-lambda-zips')
-        self.assertEqual(s3_object_list[0].key, 'latest/palp.zip')
-        self.assertEqual(s3_object_list[1].key, 'v123/palp.zip')
+        self.assertEqual(s3_object_list[0].key, 'v123/palp.zip')
 
     def test_if_file_was_uploaded_to_s3_with_bucket_prefix(self):
         self.project.set_property('bucket_prefix', 'palp/')
@@ -127,8 +126,7 @@ class UploadZipToS3Test(TestCase):
         s3_object_list = [
             o for o in self.s3.Bucket('palp-lambda-zips').objects.all()]
         self.assertEqual(s3_object_list[0].bucket_name, 'palp-lambda-zips')
-        self.assertEqual(s3_object_list[0].key, 'palp/latest/palp.zip')
-        self.assertEqual(s3_object_list[1].key, 'palp/v123/palp.zip')
+        self.assertEqual(s3_object_list[0].key, 'palp/v123/palp.zip')
 
     @mock.patch("pybuilder_aws_plugin.helpers.flush_text_line")
     def test_teamcity_output_if_set(self, flush_text_line_mock):

--- a/src/unittest/python/pybuilder_aws_plugin_tests.py
+++ b/src/unittest/python/pybuilder_aws_plugin_tests.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import tempfile
 import zipfile
-from unittest import TestCase
+from unittest2 import TestCase
 
 import boto3
 import mock

--- a/src/unittest/python/pybuilder_aws_plugin_tests.py
+++ b/src/unittest/python/pybuilder_aws_plugin_tests.py
@@ -89,7 +89,8 @@ class PackageLambdaCodeTest(TestCase):
 class TestsWithS3(TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp(prefix='palp-')
-        self.project = Project(basedir=self.tempdir, name='palp', version='123')
+        self.project = Project(
+            basedir=self.tempdir, name='palp', version='123')
         self.project.set_property('dir_target', 'target')
         self.bucket_name = 'palp-lambda-zips'
         self.project.set_property(
@@ -140,7 +141,8 @@ class UploadZipToS3Test(TestsWithS3):
         upload_zip_to_s3(self.project, mock.MagicMock(Logger))
 
         flush_text_line_mock.assert_called_with(
-                "##teamcity[setParameter name='palp_keyname' value='v123/palp.zip']")
+            ("##teamcity[setParameter "
+             "name='palp_keyname' value='v123/palp.zip']"))
 
     @mock.patch("pybuilder_aws_plugin.helpers.flush_text_line")
     def test_teamcity_output_if_not_set(self, flush_text_line_mock):
@@ -164,27 +166,34 @@ class UploadZipToS3Test(TestsWithS3):
 class LambdaReleaseTest(TestsWithS3):
     def test_release_successful(self):
         upload_zip_to_s3(self.project, mock.MagicMock(Logger))
-        lambda_release(self.project,mock.MagicMock(Logger))
-        s3_keys = [o.key for o in self.s3.Bucket(self.bucket_name).objects.all()]
+        lambda_release(self.project, mock.MagicMock(Logger))
+        s3_keys = [o.key for o
+                   in self.s3.Bucket(self.bucket_name).objects.all()]
         release_keyname = '{0}latest/{1}.zip'.format(
-                self.project.get_property('bucket_prefix'),self.project.name)
+                self.project.get_property('bucket_prefix'), self.project.name)
         self.assertTrue(release_keyname in s3_keys)
-        s3_grants=self.s3.Object(
-                bucket_name=self.bucket_name, key=release_keyname).Acl().grants
-        self.assertDictContainsSubset({"Permission":"FULL_CONTROL"},s3_grants[0],
-                                      "Default ACL of FULL_CONTROL not found!")
+        s3_grants = self.s3.Object(
+            bucket_name=self.bucket_name, key=release_keyname).Acl().grants
+        self.assertDictContainsSubset(
+            {"Permission": "FULL_CONTROL"},
+            s3_grants[0],
+            "Default ACL of FULL_CONTROL not found!")
 
     def test_release_successful_with_bucket_prefix(self):
-        self.project.set_property('bucket_prefix','palp/')
+        self.project.set_property('bucket_prefix', 'palp/')
         upload_zip_to_s3(self.project, mock.MagicMock(Logger))
-        lambda_release(self.project,mock.MagicMock(Logger))
-        s3_keys = [o.key for o in self.s3.Bucket(self.bucket_name).objects.all()]
+        lambda_release(self.project, mock.MagicMock(Logger))
+        s3_keys = [o.key for o
+                   in self.s3.Bucket(self.bucket_name).objects.all()]
         release_keyname = '{0}latest/{1}.zip'.format(
-                self.project.get_property('bucket_prefix'),self.project.name)
+                self.project.get_property('bucket_prefix'), self.project.name)
         self.assertTrue(release_keyname in s3_keys)
-        s3_grants=self.s3.Object(
+        s3_grants = self.s3.Object(
                 bucket_name=self.bucket_name, key=release_keyname).Acl().grants
-        self.assertDictContainsSubset({"Permission":"FULL_CONTROL"},s3_grants[0])
+        self.assertDictContainsSubset(
+            {"Permission": "FULL_CONTROL"},
+            s3_grants[0])
+
 
 class TestPrepareDependenciesDir(TestCase):
     """Testcases for prepare_dependencies_dir()"""
@@ -260,12 +269,13 @@ class TestPrepareDependenciesDir(TestCase):
         prepare_dependencies_dir(
                 self.mock_logger, self.input_project, 'targetdir')
         self.assertEqual(
-                list(self.mock_popen.call_args_list), [
-                    mock.call(
-                            ['pip', 'install', '--target', 'targetdir', '--index-url',
-                             'http://example.domain', 'a'],
-                            stdout=subprocess.PIPE),
-                ])
+            list(self.mock_popen.call_args_list),
+            [
+                mock.call(
+                    ['pip', 'install', '--target', 'targetdir', '--index-url',
+                        'http://example.domain', 'a'],
+                    stdout=subprocess.PIPE),
+            ])
 
     def test_prepare_dependencies_reports_errors(self):
         self.input_project.depends_on('a')

--- a/src/unittest/python/pybuilder_aws_plugin_tests.py
+++ b/src/unittest/python/pybuilder_aws_plugin_tests.py
@@ -18,6 +18,7 @@ from pybuilder.errors import BuildFailedException
 from pybuilder_aws_plugin import (package_lambda_code,
                                   upload_zip_to_s3,
                                   initialize_plugin,
+                                  lambda_release,
                                   )
 from pybuilder_aws_plugin.lambda_tasks import prepare_dependencies_dir
 from pybuilder_aws_plugin.helpers import (check_acl_parameter_validity,
@@ -85,14 +86,15 @@ class PackageLambdaCodeTest(TestCase):
         self.assertEqual(sorted(zf.namelist()), expected)
 
 
-class UploadZipToS3Test(TestCase):
+class TestsWithS3(TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp(prefix='palp-')
         self.project = Project(basedir=self.tempdir, name='palp', version='123')
         self.project.set_property('dir_target', 'target')
-        self.project.set_property('bucket_name', 'palp-lambda-zips')
+        self.bucket_name = 'palp-lambda-zips'
         self.project.set_property(
-            'lambda_file_access_control', 'bucket-owner-full-control')
+                'lambda_file_access_control', 'bucket-owner-full-control')
+        self.project.set_property('bucket_name', self.bucket_name)
         self.project.set_property('bucket_prefix', '')
         self.dir_target = os.path.join(self.tempdir, 'target')
         os.mkdir(self.dir_target)
@@ -104,12 +106,14 @@ class UploadZipToS3Test(TestCase):
         self.my_mock_s3 = mock_s3()
         self.my_mock_s3.start()
         self.s3 = boto3.resource('s3')
-        self.s3.create_bucket(Bucket='palp-lambda-zips')
+        self.s3.create_bucket(Bucket=self.bucket_name)
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
         self.my_mock_s3.stop()
 
+
+class UploadZipToS3Test(TestsWithS3):
     def test_if_file_was_uploaded_to_s3(self):
         upload_zip_to_s3(self.project, mock.MagicMock(Logger))
 
@@ -136,7 +140,7 @@ class UploadZipToS3Test(TestCase):
         upload_zip_to_s3(self.project, mock.MagicMock(Logger))
 
         flush_text_line_mock.assert_called_with(
-            "##teamcity[setParameter name='palp_keyname' value='v123/palp.zip']")
+                "##teamcity[setParameter name='palp_keyname' value='v123/palp.zip']")
 
     @mock.patch("pybuilder_aws_plugin.helpers.flush_text_line")
     def test_teamcity_output_if_not_set(self, flush_text_line_mock):
@@ -157,18 +161,43 @@ class UploadZipToS3Test(TestCase):
         pass
 
 
+class LambdaReleaseTest(TestsWithS3):
+    def test_release_successful(self):
+        upload_zip_to_s3(self.project, mock.MagicMock(Logger))
+        lambda_release(self.project,mock.MagicMock(Logger))
+        s3_keys = [o.key for o in self.s3.Bucket(self.bucket_name).objects.all()]
+        release_keyname = '{0}latest/{1}.zip'.format(
+                self.project.get_property('bucket_prefix'),self.project.name)
+        self.assertTrue(release_keyname in s3_keys)
+        s3_grants=self.s3.Object(
+                bucket_name=self.bucket_name, key=release_keyname).Acl().grants
+        self.assertDictContainsSubset({"Permission":"FULL_CONTROL"},s3_grants[0],
+                                      "Default ACL of FULL_CONTROL not found!")
+
+    def test_release_successful_with_bucket_prefix(self):
+        self.project.set_property('bucket_prefix','palp/')
+        upload_zip_to_s3(self.project, mock.MagicMock(Logger))
+        lambda_release(self.project,mock.MagicMock(Logger))
+        s3_keys = [o.key for o in self.s3.Bucket(self.bucket_name).objects.all()]
+        release_keyname = '{0}latest/{1}.zip'.format(
+                self.project.get_property('bucket_prefix'),self.project.name)
+        self.assertTrue(release_keyname in s3_keys)
+        s3_grants=self.s3.Object(
+                bucket_name=self.bucket_name, key=release_keyname).Acl().grants
+        self.assertDictContainsSubset({"Permission":"FULL_CONTROL"},s3_grants[0])
+
 class TestPrepareDependenciesDir(TestCase):
     """Testcases for prepare_dependencies_dir()"""
 
     def setUp(self):
         self.patch_popen = mock.patch(
-            'pybuilder_aws_plugin.lambda_tasks.subprocess.Popen')
+                'pybuilder_aws_plugin.lambda_tasks.subprocess.Popen')
         self.mock_popen = self.patch_popen.start()
         self.mock_process = mock.Mock()
         self.mock_process.returncode = 0
         self.mock_popen.return_value = self.mock_process
         self.patch_aspip = mock.patch(
-            'pybuilder_aws_plugin.lambda_tasks.as_pip_argument')
+                'pybuilder_aws_plugin.lambda_tasks.as_pip_argument')
         self.mock_aspip = self.patch_aspip.start()
         self.mock_aspip.side_effect = lambda x: x.name
         self.input_project = Project('.')
@@ -183,68 +212,70 @@ class TestPrepareDependenciesDir(TestCase):
         for dependency in ['a', 'b', 'c']:
             self.input_project.depends_on(dependency)
         prepare_dependencies_dir(
-            self.mock_logger, self.input_project, 'targetdir')
+                self.mock_logger, self.input_project, 'targetdir')
         self.assertEqual(self.mock_aspip.call_count, 3)
         self.assertNotEqual(self.mock_aspip.call_count, 4)
         self.assertEqual(
-            list(self.mock_popen.call_args_list), [
-                mock.call(
-                    ['pip', 'install', '--target', 'targetdir', 'a'],
-                    stdout=subprocess.PIPE),
-                mock.call(
-                    ['pip', 'install', '--target', 'targetdir', 'b'],
-                    stdout=subprocess.PIPE),
-                mock.call(
-                    ['pip', 'install', '--target', 'targetdir', 'c'],
-                    stdout=subprocess.PIPE)])
+                list(self.mock_popen.call_args_list), [
+                    mock.call(
+                            ['pip', 'install', '--target', 'targetdir', 'a'],
+                            stdout=subprocess.PIPE),
+                    mock.call(
+                            ['pip', 'install', '--target', 'targetdir', 'b'],
+                            stdout=subprocess.PIPE),
+                    mock.call(
+                            ['pip', 'install', '--target', 'targetdir', 'c'],
+                            stdout=subprocess.PIPE)])
         self.assertEqual(
-            self.mock_popen.return_value.communicate.call_count, 3)
+                self.mock_popen.return_value.communicate.call_count, 3)
         self.assertNotEqual(
-            self.mock_popen.return_value.communicate.call_count, 1)
+                self.mock_popen.return_value.communicate.call_count, 1)
 
     def test_prepare_dependencies_with_excludes(self):
         """Test prepare_dependencies_dir() w/ excludes."""
         for dependency in ['a', 'b', 'c', 'd', 'e']:
             self.input_project.depends_on(dependency)
         prepare_dependencies_dir(
-            self.mock_logger, self.input_project, 'targetdir',
-            excludes=['b', 'e', 'a'])
+                self.mock_logger, self.input_project, 'targetdir',
+                excludes=['b', 'e', 'a'])
         self.assertEqual(self.mock_aspip.call_count, 5)
         self.assertNotEqual(self.mock_aspip.call_count, 4)
         self.assertEqual(
-            list(self.mock_popen.call_args_list), [
-                mock.call(
-                    ['pip', 'install', '--target', 'targetdir', 'c'],
-                    stdout=subprocess.PIPE),
-                mock.call(
-                    ['pip', 'install', '--target', 'targetdir', 'd'],
-                    stdout=subprocess.PIPE)])
+                list(self.mock_popen.call_args_list), [
+                    mock.call(
+                            ['pip', 'install', '--target', 'targetdir', 'c'],
+                            stdout=subprocess.PIPE),
+                    mock.call(
+                            ['pip', 'install', '--target', 'targetdir', 'd'],
+                            stdout=subprocess.PIPE)])
         self.assertEqual(
-            self.mock_popen.return_value.communicate.call_count, 2)
+                self.mock_popen.return_value.communicate.call_count, 2)
         self.assertNotEqual(
-            self.mock_popen.return_value.communicate.call_count, 1)
+                self.mock_popen.return_value.communicate.call_count, 1)
 
     def test_prepare_dependencies_with_custom_index_url(self):
         self.input_project.depends_on('a')
         self.input_project.set_property('install_dependencies_index_url',
                                         'http://example.domain')
         prepare_dependencies_dir(
-            self.mock_logger, self.input_project, 'targetdir')
+                self.mock_logger, self.input_project, 'targetdir')
         self.assertEqual(
-            list(self.mock_popen.call_args_list), [
-                mock.call(
-                    ['pip', 'install', '--target', 'targetdir',  '--index-url',
-                     'http://example.domain', 'a'],
-                    stdout=subprocess.PIPE),
-            ])
+                list(self.mock_popen.call_args_list), [
+                    mock.call(
+                            ['pip', 'install', '--target', 'targetdir', '--index-url',
+                             'http://example.domain', 'a'],
+                            stdout=subprocess.PIPE),
+                ])
 
     def test_prepare_dependencies_reports_errors(self):
         self.input_project.depends_on('a')
         self.mock_process.returncode = 1
-        self.assertRaises(Exception,  prepare_dependencies_dir,
-            self.mock_logger, self.input_project, 'targetdir')
+        self.assertRaises(Exception, prepare_dependencies_dir,
+                          self.mock_logger, self.input_project, 'targetdir')
 
 
 if sys.version_info[0:2] >= (2, 7):
-    from version_specific import UploadJSONToS3
+    from version_specific import UploadJSONToS3, CfnReleaseTests
+
     UploadJSONToS3  # Linting purposes, no other use
+    CfnReleaseTests

--- a/src/unittest/python/version_specific.py
+++ b/src/unittest/python/version_specific.py
@@ -1,3 +1,8 @@
+"""
+These tests are separate since they only work with Python2 >2.6 by
+the time being. Python3 support is underway.
+"""
+
 import os
 import mock
 from unittest import TestCase
@@ -7,48 +12,48 @@ from moto import mock_s3
 from pybuilder.core import Logger, Project
 from pybuilder.errors import BuildFailedException
 
-from pybuilder_aws_plugin import upload_cfn_to_s3
+from pybuilder_aws_plugin import upload_cfn_to_s3, cfn_release
 
 
-class UploadJSONToS3(TestCase):
-    """
-    These tests are separate since they only work with Python2 >2.6 by
-    the time being. Python3 support is underway.
-    """
-
+class TestsWithS3(TestCase):
     def setUp(self):
         self.bucket_name = 'palp-cfn-json'
-        self.project = Project(basedir=os.path.dirname(__file__),
+        basedir = os.path.dirname(__file__)
+        self.project = Project(basedir=basedir,
                                name='palp', version='123')
         self.test_files = [
-            (os.path.join(os.path.dirname(__file__), 'templates'),
-             'alarm-topic.yml'),
-            (os.path.join(os.path.dirname(__file__), 'templates'),
-             'ecs-simple-webapp.yml')]
+            (os.path.join(basedir, 'templates'),'alarm-topic.yml'),
+            (os.path.join(basedir, 'templates'),'ecs-simple-webapp.yml')]
         self.project.set_property('bucket_name', self.bucket_name)
         self.project.set_property('template_key_prefix', 'palp/')
-        self.project.set_property(
-            'template_file_access_control', 'bucket-owner-full-control')
         self.project.set_property('template_files', self.test_files)
-
+        self.project.set_property(
+                'template_file_access_control', 'bucket-owner-full-control')
         self.my_mock_s3 = mock_s3()
         self.my_mock_s3.start()
         self.s3 = boto3.resource('s3')
         self.s3.create_bucket(Bucket=self.bucket_name)
 
-    def test_upload_cfn_fils(self):
+    def tearDown(self):
+        self.my_mock_s3.stop()
+
+
+class UploadJSONToS3(TestsWithS3):
+
+    def test_upload_cfn_files(self):
         upload_cfn_to_s3(self.project, mock.MagicMock(Logger))
         s3_object_list = [
             o for o in self.s3.Bucket(self.bucket_name).objects.all()]
 
         key_prefix = self.project.get_property('template_key_prefix')
         self.assertEqual(s3_object_list[0].bucket_name, self.bucket_name)
+        keys = [o.key for o in s3_object_list]
         for test_file in self.test_files:
             version_path = '{0}v{1}/{2}'.format(
-                key_prefix, self.project.version,
-                test_file[1].replace('yml', 'json'))
-            keys = [o.key for o in s3_object_list]
-            assert version_path in keys
+                    key_prefix, self.project.version,
+                    test_file[1].replace('yml', 'json'))
+            self.assertTrue(version_path in keys,
+                            "Key {0} not found in {1}".format(version_path, keys))
 
     def test_upload_fails_with_invalid_acl_value(self):
         self.project.set_property('template_file_access_control',
@@ -58,5 +63,17 @@ class UploadJSONToS3(TestCase):
                           self.project,
                           mock.MagicMock(Logger))
 
-    def tearDown(self):
-        self.my_mock_s3.stop()
+
+class CfnReleaseTests(TestsWithS3):
+
+    def test_release_successful(self):
+        upload_cfn_to_s3(self.project, mock.MagicMock(Logger))
+        cfn_release(self.project, mock.MagicMock(Logger))
+        key_prefix = self.project.get_property('template_key_prefix')
+        s3_keys = [o.key for o in self.s3.Bucket(self.bucket_name).objects.all()]
+        for (path,filename) in self.test_files:
+            key_path = '{0}latest/{1}'.format(
+                    key_prefix, filename.replace('yml', 'json'))
+            self.assertTrue(key_path in s3_keys,
+                            "Key {0} not found in {1}".format(key_path, s3_keys))
+

--- a/src/unittest/python/version_specific.py
+++ b/src/unittest/python/version_specific.py
@@ -5,7 +5,7 @@ the time being. Python3 support is underway.
 
 import os
 import mock
-from unittest import TestCase
+from unittest2 import TestCase
 
 import boto3
 from moto import mock_s3

--- a/src/unittest/python/version_specific.py
+++ b/src/unittest/python/version_specific.py
@@ -47,11 +47,8 @@ class UploadJSONToS3(TestCase):
             version_path = '{0}v{1}/{2}'.format(
                 key_prefix, self.project.version,
                 test_file[1].replace('yml', 'json'))
-            latest_path = '{0}latest/{1}'.format(
-                key_prefix, test_file[1].replace('yml', 'json'))
             keys = [o.key for o in s3_object_list]
             assert version_path in keys
-            assert latest_path in keys
 
     def test_upload_fails_with_invalid_acl_value(self):
         self.project.set_property('template_file_access_control',

--- a/src/unittest/python/version_specific.py
+++ b/src/unittest/python/version_specific.py
@@ -54,6 +54,9 @@ class UploadJSONToS3(TestsWithS3):
                     test_file[1].replace('yml', 'json'))
             self.assertTrue(version_path in keys,
                             "Key {0} not found in {1}".format(version_path, keys))
+            s3_grants=self.s3.Object(
+                    bucket_name=self.bucket_name, key=version_path).Acl().grants
+            self.assertDictContainsSubset({"Permission":"FULL_CONTROL"},s3_grants[0])
 
     def test_upload_fails_with_invalid_acl_value(self):
         self.project.set_property('template_file_access_control',
@@ -76,4 +79,7 @@ class CfnReleaseTests(TestsWithS3):
                     key_prefix, filename.replace('yml', 'json'))
             self.assertTrue(key_path in s3_keys,
                             "Key {0} not found in {1}".format(key_path, s3_keys))
+            s3_grants=self.s3.Object(
+                    bucket_name=self.bucket_name, key=key_path).Acl().grants
+            self.assertDictContainsSubset({"Permission":"FULL_CONTROL"},s3_grants[0])
 

--- a/src/unittest/python/version_specific.py
+++ b/src/unittest/python/version_specific.py
@@ -22,8 +22,8 @@ class TestsWithS3(TestCase):
         self.project = Project(basedir=basedir,
                                name='palp', version='123')
         self.test_files = [
-            (os.path.join(basedir, 'templates'),'alarm-topic.yml'),
-            (os.path.join(basedir, 'templates'),'ecs-simple-webapp.yml')]
+            (os.path.join(basedir, 'templates'), 'alarm-topic.yml'),
+            (os.path.join(basedir, 'templates'), 'ecs-simple-webapp.yml')]
         self.project.set_property('bucket_name', self.bucket_name)
         self.project.set_property('template_key_prefix', 'palp/')
         self.project.set_property('template_files', self.test_files)
@@ -52,11 +52,14 @@ class UploadJSONToS3(TestsWithS3):
             version_path = '{0}v{1}/{2}'.format(
                     key_prefix, self.project.version,
                     test_file[1].replace('yml', 'json'))
-            self.assertTrue(version_path in keys,
-                            "Key {0} not found in {1}".format(version_path, keys))
-            s3_grants=self.s3.Object(
-                    bucket_name=self.bucket_name, key=version_path).Acl().grants
-            self.assertDictContainsSubset({"Permission":"FULL_CONTROL"},s3_grants[0])
+            self.assertTrue(
+                version_path in keys,
+                "Key {0} not found in {1}".format(version_path, keys))
+            s3_grants = self.s3.Object(
+                bucket_name=self.bucket_name, key=version_path).Acl().grants
+            self.assertDictContainsSubset(
+                {"Permission": "FULL_CONTROL"},
+                s3_grants[0])
 
     def test_upload_fails_with_invalid_acl_value(self):
         self.project.set_property('template_file_access_control',
@@ -73,13 +76,16 @@ class CfnReleaseTests(TestsWithS3):
         upload_cfn_to_s3(self.project, mock.MagicMock(Logger))
         cfn_release(self.project, mock.MagicMock(Logger))
         key_prefix = self.project.get_property('template_key_prefix')
-        s3_keys = [o.key for o in self.s3.Bucket(self.bucket_name).objects.all()]
-        for (path,filename) in self.test_files:
+        s3_keys = [o.key for o
+                   in self.s3.Bucket(self.bucket_name).objects.all()]
+        for (path, filename) in self.test_files:
             key_path = '{0}latest/{1}'.format(
                     key_prefix, filename.replace('yml', 'json'))
-            self.assertTrue(key_path in s3_keys,
-                            "Key {0} not found in {1}".format(key_path, s3_keys))
-            s3_grants=self.s3.Object(
+            self.assertTrue(
+                key_path in s3_keys,
+                "Key {0} not found in {1}".format(key_path, s3_keys))
+            s3_grants = self.s3.Object(
                     bucket_name=self.bucket_name, key=key_path).Acl().grants
-            self.assertDictContainsSubset({"Permission":"FULL_CONTROL"},s3_grants[0])
-
+            self.assertDictContainsSubset(
+                {"Permission": "FULL_CONTROL"},
+                s3_grants[0])

--- a/src/unittest/python/version_specific.py
+++ b/src/unittest/python/version_specific.py
@@ -1,6 +1,6 @@
 """
-These tests are separate since they only work with Python2 >2.6 by
-the time being. Python3 support is underway.
+These tests are separate since they only work with Python2 >2.6 for the time
+being. Python3 support is underway.
 """
 
 import os


### PR DESCRIPTION
Releasing on S3 and uploading should be separate steps to enable the following workflow:
1. Upload new version
2. Run integration tests
3. Release new version under _latest_ tag
