### PR TITLE
Improvements: Simply IntelliJ setup and add TeamCity build result message

### DIFF
--- a/src/main/python/pybuilder_aws_plugin/__init__.py
+++ b/src/main/python/pybuilder_aws_plugin/__init__.py
@@ -8,15 +8,22 @@ from pybuilder.core import init, task, depends
 
 from .lambda_tasks import upload_zip_to_s3, package_lambda_code, lambda_release
 
+
 if sys.version_info[0:2] >= (2, 7):
     # cfn-sphere needs Python 2.7, skip cfn handling for older Python versions
     from .cfn_tasks import upload_cfn_to_s3, cfn_release
 
+    from .helpers import teamcity_append_build_status
+
     @task(description='Release on S3 by copying everything to latest')
     @depends('lambda_release',
              'cfn_release')
-    def release_custom_resource():
-        pass
+    def release_custom_resource(project):
+        if project.get_property('teamcity_output'):
+            teamcity_append_build_status("Released {0} in {1}".format(
+                project.version,
+                project.get_property('bucket_name')
+            ))
 
     @task(description='Upload lambda and cfn results to S3')
     @depends('package_lambda_code',

--- a/src/main/python/pybuilder_aws_plugin/helpers.py
+++ b/src/main/python/pybuilder_aws_plugin/helpers.py
@@ -48,3 +48,16 @@ def teamcity_helper(tc_param, keyname):
             "##teamcity[setParameter name='{0}' value='{1}']".format(
                     tc_param, keyname
             ))
+
+# copied from https://github.com/JetBrains/teamcity-messages/blob/942584909b2ce51e62a7c3360c5e1d1af6e1ef5a/teamcity/messages.py#L13
+_quote = {"'": "|'", "|": "||", "\n": "|n", "\r": "|r", '[': '|[', ']': '|]'}
+
+
+def _teamcity_escape_value(value):
+    return "".join(_quote.get(x, x) for x in value)
+
+
+def teamcity_append_build_status(text):
+    flush_text_line(
+        "##teamcity[buildStatus text='{build.status.text} %s']" % _teamcity_escape_value(text)
+    )

--- a/src/unittest/python/pybuilder_aws_plugin_tests.py
+++ b/src/unittest/python/pybuilder_aws_plugin_tests.py
@@ -57,7 +57,8 @@ class PackageLambdaCodeTest(TestCase):
         self.tempdir = tempfile.mkdtemp(prefix='palp-')
         self.testdir = os.path.join(self.tempdir, 'package_lambda_code_test')
         self.project = Project(basedir=self.testdir, name='palp')
-        shutil.copytree('src/unittest/python/package_lambda_code_test/',
+        source_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)),'package_lambda_code_test/')
+        shutil.copytree(source_dir,
                         self.testdir)
 
         self.project.set_property('dir_target', 'target')

--- a/src/unittest/python/version_specific.py
+++ b/src/unittest/python/version_specific.py
@@ -12,7 +12,7 @@ from moto import mock_s3
 from pybuilder.core import Logger, Project
 from pybuilder.errors import BuildFailedException
 
-from pybuilder_aws_plugin import upload_cfn_to_s3, cfn_release
+from pybuilder_aws_plugin import upload_cfn_to_s3, cfn_release, release_custom_resource
 
 
 class TestsWithS3(TestCase):
@@ -89,3 +89,12 @@ class CfnReleaseTests(TestsWithS3):
             self.assertDictContainsSubset(
                 {"Permission": "FULL_CONTROL"},
                 s3_grants[0])
+
+    @mock.patch("pybuilder_aws_plugin.helpers.flush_text_line")
+    def test_release_custom_resource_teamcity_build_status(self, flush_text_line_mock):
+        self.project.set_property('teamcity_output', True)
+
+        release_custom_resource(self.project)
+
+        flush_text_line_mock.assert_called_with(
+                ("##teamcity[buildStatus text='{build.status.text} Released 123 in palp-cfn-json']"))


### PR DESCRIPTION
This helps IntelliJ users because IntelliJ will set src/unittest/python as the CWD for the unittest by default.
