### PR TITLE
fix plugin to work with dependencies and requirements.txt as well

### DIFF
--- a/src/main/python/pybuilder_aws_plugin/lambda_tasks.py
+++ b/src/main/python/pybuilder_aws_plugin/lambda_tasks.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import ast
 import os
 import subprocess
 import zipfile
 
 from pybuilder.core import depends, task
+from pybuilder.plugins.python.distutils_plugin import build_install_dependencies_string
 
 from .helpers import (upload_helper,
                       copy_helper,
@@ -27,14 +29,10 @@ def zip_recursive(archive, directory, folder=''):
                     folder=os.path.join(folder, item))
 
 
-def as_pip_argument(dependency):
-    return "{0}{1}".format(dependency.name, dependency.version or "")
-
-
 def prepare_dependencies_dir(logger, project, target_directory, excludes=None):
     """Get all dependencies from project and install them to given dir"""
     excludes = excludes or []
-    dependencies = map(lambda dep: as_pip_argument(dep), project.dependencies)
+    dependencies = ast.literal_eval(build_install_dependencies_string(project))
 
     index_url = project.get_property('install_dependencies_index_url')
     if index_url:

--- a/src/unittest/python/pybuilder_aws_plugin_tests.py
+++ b/src/unittest/python/pybuilder_aws_plugin_tests.py
@@ -206,16 +206,11 @@ class TestPrepareDependenciesDir(TestCase):
         self.mock_process = mock.Mock()
         self.mock_process.returncode = 0
         self.mock_popen.return_value = self.mock_process
-        self.patch_aspip = mock.patch(
-                'pybuilder_aws_plugin.lambda_tasks.as_pip_argument')
-        self.mock_aspip = self.patch_aspip.start()
-        self.mock_aspip.side_effect = lambda x: x.name
         self.input_project = Project('.')
         self.mock_logger = mock.Mock()
 
     def tearDown(self):
         self.patch_popen.stop()
-        self.patch_aspip.stop()
 
     def test_prepare_dependencies_no_excludes(self):
         """Test prepare_dependencies_dir() w/o excludes."""
@@ -223,8 +218,6 @@ class TestPrepareDependenciesDir(TestCase):
             self.input_project.depends_on(dependency)
         prepare_dependencies_dir(
                 self.mock_logger, self.input_project, 'targetdir')
-        self.assertEqual(self.mock_aspip.call_count, 3)
-        self.assertNotEqual(self.mock_aspip.call_count, 4)
         self.assertEqual(
                 list(self.mock_popen.call_args_list), [
                     mock.call(
@@ -248,8 +241,6 @@ class TestPrepareDependenciesDir(TestCase):
         prepare_dependencies_dir(
                 self.mock_logger, self.input_project, 'targetdir',
                 excludes=['b', 'e', 'a'])
-        self.assertEqual(self.mock_aspip.call_count, 5)
-        self.assertNotEqual(self.mock_aspip.call_count, 4)
         self.assertEqual(
                 list(self.mock_popen.call_args_list), [
                     mock.call(


### PR DESCRIPTION
Seems this plugin only works when dependencies are specified in build.py using depends_on() function. There is also an option to specify project dependencies using requirements.txt file. In this case, plugin fails to go over dependencies.

This fix uses an existing function from distutils plugin to iterate over requirements.txt dependencies and prepare single list of project dependencies.
